### PR TITLE
feature/newsAdminApi - AgetAdminNewsDetail 수정

### DIFF
--- a/hexa-homepage-backend-main-app/src/main/java/pro/hexa/backend/main/api/domain/news/service/NewsAdminPageService.java
+++ b/hexa-homepage-backend-main-app/src/main/java/pro/hexa/backend/main/api/domain/news/service/NewsAdminPageService.java
@@ -49,8 +49,9 @@ public class NewsAdminPageService {
     public AdminNewsDetailResponse getAdminNewsDetail(Long newsId) {
         AdminNewsDetailResponse adminNewsDetailResponse = new AdminNewsDetailResponse();
 
-        newsRepository.findById(newsId)
-                .ifPresent(adminNewsDetailResponse::fromNews);
+        News foundNews = newsRepository.findById(newsId)
+                .orElseThrow((() -> new BadRequestException(BadRequestType.NEWS_NOT_FOUND)));
+        adminNewsDetailResponse.fromNews(foundNews);
 
         return adminNewsDetailResponse;
     }


### PR DESCRIPTION
- 문제상황 
  : 기존 코드로 뉴스 조회 요청 테스트 시, 존재하지 않는 newsId로 요청을 보냈을 때 NOT FOUND 에러가 아닌 null 데이터가 응답되는 것을 확인하였습니다. 
- 원인
  : 기존 코드에서 ifPresent()는 null 값일 때 에러를 반환하는데, 
     newsRepository.findById(newsId) 에서 데이터가 존재하지 않을 때 null 아닌 Optional.Empty 가 반환되어 에러처리 되지 못한 것 같습니다.
- 해결 
  : 에러 처리하도록 코드 수정 하였습니다. 